### PR TITLE
Update model to include missing release calendar fields

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,2 +1,6 @@
 CVE-2020-26160 # No upgrade path for github.com/dgrijalva/jwt-go. See: https://ossindex.sonatype.org/vulnerability/c16fb56d-9de6-4065-9fca-d2b4cfb13020?component-type=golang&component-name=github.com%2Fdgrijalva%2Fjwt-go&utm_source=nancy-client&utm_medium=integration&utm_content=0.0.0-dev
-
+sonatype-2021-4899 # 1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account.
+CVE-2022-29153 # HashiCorp Consul and Consul Enterprise through 2022-04-12 allow SSRF.
+sonatype-2021-1401 # 1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account.
+sonatype-2019-0890 # 1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account.
+CVE-2022-21698 # client_golang is the instrumentation library for Go applications in prometheus, and the promhttp package in client_golang provides tooling around HTTP servers and clients.

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -34,6 +34,11 @@ var (
 		ReleaseDate:     "",
 		Title:           "anyTitle1",
 		TraceID:         "anyTraceID1",
+		DateChanges:     []models.ReleaseDateDetails{},
+		Cancelled:       false,
+		Finalised:       false,
+		ProvisionalDate: "",
+		Published:       false,
 	}
 
 	expectedEvent2 = &models.SearchDataImportModel{

--- a/models/elastic.go
+++ b/models/elastic.go
@@ -2,18 +2,23 @@ package models
 
 // EsModel holds an individual content data
 type EsModel struct {
-	DataType        string   `json:"type"`
-	URI             string   `json:"uri"`
-	JobID           string   `json:"job_id"`
-	SearchIndex     string   `json:"search_index"`
-	CDID            string   `json:"cdid"`
-	DatasetID       string   `json:"dataset_id"`
-	Keywords        []string `json:"keywords"`
-	MetaDescription string   `json:"meta_description"`
-	ReleaseDate     string   `json:"release_date,omitempty"`
-	Summary         string   `json:"summary"`
-	Title           string   `json:"title"`
-	Topics          []string `json:"topics"`
+	DataType        string              `json:"type"`
+	URI             string              `json:"uri"`
+	JobID           string              `json:"job_id"`
+	SearchIndex     string              `json:"search_index"`
+	CDID            string              `json:"cdid"`
+	DatasetID       string              `json:"dataset_id"`
+	Keywords        []string            `json:"keywords"`
+	MetaDescription string              `json:"meta_description"`
+	ReleaseDate     string              `json:"release_date,omitempty"`
+	Summary         string              `json:"summary"`
+	Title           string              `json:"title"`
+	Topics          []string            `json:"topics"`
+	DateChanges     []ReleaseDateChange `json:"date_changes,omitempty"`
+	Cancelled       bool                `json:"cancelled,omitempty"`
+	Finalised       bool                `json:"finalised,omitempty"`
+	ProvisionalDate string              `json:"provisional_date,omitempty"`
+	Published       bool                `json:"published,omitempty"`
 }
 
 // EsBulkResponse holds a response from ES
@@ -40,4 +45,10 @@ type EsBulkItemResponseError struct {
 	IndexUUID string `json:"index_uuid"`
 	Shard     string `json:"shard"`
 	Index     string `json:"index"`
+}
+
+// ReleaseDateChange represent a date change of a release
+type ReleaseDateChange struct {
+	ChangeNotice string `json:"change_notice"`
+	Date         string `json:"previous_date"`
 }

--- a/models/event.go
+++ b/models/event.go
@@ -2,18 +2,29 @@ package models
 
 // SearchDataImportModel provides an avro structure for a SearchDataImportModel Called event
 type SearchDataImportModel struct {
-	UID             string   `avro:"uid"`
-	URI             string   `avro:"uri"`
-	DataType        string   `avro:"type"`
-	JobID           string   `avro:"job_id"`
-	SearchIndex     string   `avro:"search_index"`
-	CDID            string   `avro:"cdid"`
-	DatasetID       string   `avro:"dataset_id"`
-	Keywords        []string `avro:"keywords"`
-	MetaDescription string   `avro:"meta_description"`
-	ReleaseDate     string   `avro:"release_date"`
-	Summary         string   `avro:"summary"`
-	Title           string   `avro:"title"`
-	Topics          []string `avro:"topics"`
-	TraceID         string   `avro:"trace_id"`
+	UID             string               `avro:"uid"`
+	URI             string               `avro:"uri"`
+	DataType        string               `avro:"type"`
+	JobID           string               `avro:"job_id"`
+	SearchIndex     string               `avro:"search_index"`
+	CDID            string               `avro:"cdid"`
+	DatasetID       string               `avro:"dataset_id"`
+	Keywords        []string             `avro:"keywords"`
+	MetaDescription string               `avro:"meta_description"`
+	ReleaseDate     string               `avro:"release_date"`
+	Summary         string               `avro:"summary"`
+	Title           string               `avro:"title"`
+	Topics          []string             `avro:"topics"`
+	TraceID         string               `avro:"trace_id"`
+	DateChanges     []ReleaseDateDetails `avro:"date_changes"`
+	Cancelled       bool                 `avro:"cancelled"`
+	Finalised       bool                 `avro:"finalised"`
+	ProvisionalDate string               `avro:"provisional_date"`
+	Published       bool                 `avro:"published"`
+}
+
+// ReleaseDateChange represent a date change of a release
+type ReleaseDateDetails struct {
+	ChangeNotice string `avro:"change_notice"`
+	Date         string `avro:"previous_date"`
 }

--- a/models/event.go
+++ b/models/event.go
@@ -23,7 +23,7 @@ type SearchDataImportModel struct {
 	Published       bool                 `avro:"published"`
 }
 
-// ReleaseDateChange represent a date change of a release
+// ReleaseDateDetails represents a change of release date
 type ReleaseDateDetails struct {
 	ChangeNotice string `avro:"change_notice"`
 	Date         string `avro:"previous_date"`

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -21,7 +21,18 @@ var searchDataImportEvent = `{
     {"name": "summary", "type": "string", "default": ""},
     {"name": "title", "type": "string", "default": ""},
     {"name": "topics", "type": {"type":"array","items":"string"}},
-    {"name": "trace_id", "type": "string", "default": ""}
+    {"name": "trace_id", "type": "string", "default": ""},
+    {"name": "cancelled", "type": "boolean", "default": false},
+    {"name": "finalised", "type": "boolean", "default": false},
+    {"name": "published", "type": "boolean", "default": false},
+    {"name": "date_changes", "type": {"type":"array","items":{
+     "name": "ReleaseDateDetails",
+     "type" : "record",
+     "fields" : [
+      {"name": "change_notice", "type": "string", "default": ""},
+      {"name": "previous_date", "type": "string", "default": ""}
+    ]}}},
+    {"name": "provisional_date", "type": "string", "default": ""}
   ]
 }`
 

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -32,6 +32,13 @@ func (t *Transform) TransformEventModelToEsModel(eventModel *models.SearchDataIm
 		Summary:         eventModel.Summary,
 		Title:           eventModel.Title,
 		Topics:          eventModel.Topics,
+		Cancelled:       eventModel.Cancelled,
+		Finalised:       eventModel.Finalised,
+		ProvisionalDate: eventModel.ProvisionalDate,
+		Published:       eventModel.Published,
+	}
+	for _, data := range eventModel.DateChanges {
+		esModels.DateChanges = append(esModels.DateChanges, models.ReleaseDateChange(data))
 	}
 	return &esModels
 }


### PR DESCRIPTION
### What

Similar to the code changes to dp-search-data-extractor. This pr includes the following:
Extension to the new search service to handle data fields for release calendar previously not considered due to not being needed by sitesearch.

The below field extensions are for the content **type**: `release`

### How to review

Trello ticket: https://trello.com/c/4mlvciPr/1256-search-data-extractor-update-model-to-include-missing-release-calendar-fields-incl-updating-transform
This pr is done according to the above trello ticket. 

### Who can review

Anyone except me