### PR TITLE
remove omitempty from json tags for boolean values that must be indexed

### DIFF
--- a/models/elastic.go
+++ b/models/elastic.go
@@ -15,10 +15,10 @@ type EsModel struct {
 	Title           string              `json:"title"`
 	Topics          []string            `json:"topics"`
 	DateChanges     []ReleaseDateChange `json:"date_changes,omitempty"`
-	Cancelled       bool                `json:"cancelled,omitempty"`
-	Finalised       bool                `json:"finalised,omitempty"`
+	Cancelled       bool                `json:"cancelled"`
+	Finalised       bool                `json:"finalised"`
 	ProvisionalDate string              `json:"provisional_date,omitempty"`
-	Published       bool                `json:"published,omitempty"`
+	Published       bool                `json:"published"`
 	Language        string              `json:"language,omitempty"`
 	Survey          string              `json:"survey,omitempty"`
 }


### PR DESCRIPTION
### What

Certain Release attributes such as Published, Cancelled, and Finalised must be indexed, and so the json `omitempty` tag cannot be used for these values

### How to review

Review code and ensure tests pass

### Who can review

Anyone
