### PR TITLE
fix use of time.After() to clean up timer resource

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,12 +70,16 @@ linters:
 
 issues:
   exclude-rules:
+    - path: \.go
+      linters:
+        - typecheck
     - path: _test\.go
       linters:
         - gocyclo
         - errcheck
         - dupl
         - gosec
+        - typecheck
   new: false
 
 # golangci.com configuration

--- a/event/consumer.go
+++ b/event/consumer.go
@@ -54,6 +54,12 @@ func (consumer *Consumer) Consume(
 			delay := time.NewTimer(cfg.BatchWaitTime)
 			select {
 			case msg := <-messageConsumer.Channels().Upstream:
+				// Ensure timer is stopped and its resources are freed
+				if !delay.Stop() {
+					// if the timer has been stopped then read from the channel
+					<-delay.C
+				}
+
 				AddMessageToBatch(ctx, cfg, batch, msg, batchHandler)
 				msg.Release()
 


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Fix use of `time.After()` to clean up the timer resource
- This eliminates resource leakage due to using `time.After()` in wrong manner
- Ignore `typecheck` in lint

### How to review
**Describe the steps required to test the changes.**
- Check if the code changes make sense
- Check if the test passes

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone