### PR TITLE
Release 0.11.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,12 +70,16 @@ linters:
 
 issues:
   exclude-rules:
+    - path: \.go
+      linters:
+        - typecheck
     - path: _test\.go
       linters:
         - gocyclo
         - errcheck
         - dupl
         - gosec
+        - typecheck
   new: false
 
 # golangci.com configuration

--- a/event/consumer.go
+++ b/event/consumer.go
@@ -51,18 +51,30 @@ func (consumer *Consumer) Consume(
 		// Wait a batch full of messages.
 		// If we do not get any messages for a time, just process the messages already in the batch.
 		for {
+			delay := time.NewTimer(cfg.BatchWaitTime)
 			select {
 			case msg := <-messageConsumer.Channels().Upstream:
+				// Ensure timer is stopped and its resources are freed
+				if !delay.Stop() {
+					// if the timer has been stopped then read from the channel
+					<-delay.C
+				}
+
 				AddMessageToBatch(ctx, cfg, batch, msg, batchHandler)
 				msg.Release()
 
-			case <-time.After(cfg.BatchWaitTime):
+			case <-delay.C:
 				if batch.IsEmpty() {
 					continue
 				}
 				ProcessBatch(ctx, cfg, batchHandler, batch, "timeout")
 
 			case <-consumer.closing:
+				// Ensure timer is stopped and its resources are freed
+				if !delay.Stop() {
+					// if the timer has been stopped then read from the channel
+					<-delay.C
+				}
 				log.Info(ctx, "closing event consumer loop")
 				close(consumer.closing)
 				return


### PR DESCRIPTION
- fix use of `time.After()` to clean up timer resource by @justinpjose in https://github.com/ONSdigital/dp-search-data-importer/pull/37

**Release PR: https://github.com/ONSdigital/dp-search-data-importer/pull/38**