### PR TITLE
Fix false alerts kafka lags

### DIFF
--- a/event/consumer.go
+++ b/event/consumer.go
@@ -61,7 +61,7 @@ func (consumer *Consumer) Consume(
 				}
 
 				AddMessageToBatch(ctx, cfg, batch, msg, batchHandler)
-				msg.Release()
+				msg.CommitAndRelease()
 
 			case <-delay.C:
 				if batch.IsEmpty() {
@@ -111,12 +111,10 @@ func ProcessBatch(ctx context.Context, cfg *config.Config, handler Handler, batc
 	err := handler.Handle(ctx, cfg.ElasticSearchAPIURL, batch.Events())
 	if err != nil {
 		log.Error(ctx, "error handling batch", err)
-		batch.Commit()
 		return
 	}
 
 	log.Info(ctx, "batch event processed - committing")
-	batch.Commit()
 }
 
 // Close safely closes the consumer and releases all resources

--- a/event/consumer_test.go
+++ b/event/consumer_test.go
@@ -125,8 +125,7 @@ func TestConsumeWithOneMessage(t *testing.T) {
 			})
 			Convey("And the message is committed and the consumer is released", func() {
 				<-consumer.Closed
-				So(len(message.CommitCalls()), ShouldEqual, 1)
-				So(len(message.ReleaseCalls()), ShouldEqual, 1)
+				So(len(message.CommitAndReleaseCalls()), ShouldEqual, 1)
 			})
 		})
 	})
@@ -165,8 +164,7 @@ func TestConsumeWithEmptyTopicString(t *testing.T) {
 			})
 			Convey("And the message is committed and the consumer is released", func() {
 				<-consumer.Closed
-				So(len(message.CommitCalls()), ShouldEqual, 1)
-				So(len(message.ReleaseCalls()), ShouldEqual, 1)
+				So(len(message.CommitAndReleaseCalls()), ShouldEqual, 1)
 			})
 		})
 	})
@@ -205,8 +203,7 @@ func TestConsumeWithMissingTopicElement(t *testing.T) {
 			})
 			Convey("And the message is committed and the consumer is released", func() {
 				<-consumer.Closed
-				So(len(message.CommitCalls()), ShouldEqual, 1)
-				So(len(message.ReleaseCalls()), ShouldEqual, 1)
+				So(len(message.CommitAndReleaseCalls()), ShouldEqual, 1)
 			})
 		})
 	})
@@ -245,8 +242,7 @@ func TestConsumeWithEmptyTopicArray(t *testing.T) {
 			})
 			Convey("And the message is committed and the consumer is released", func() {
 				<-consumer.Closed
-				So(len(message.CommitCalls()), ShouldEqual, 1)
-				So(len(message.ReleaseCalls()), ShouldEqual, 1)
+				So(len(message.CommitAndReleaseCalls()), ShouldEqual, 1)
 			})
 		})
 	})
@@ -287,9 +283,8 @@ func TestConsumeWithTwoMessages(t *testing.T) {
 			})
 			Convey("The message is committed and the consumer is released", func() {
 				<-consumer.Closed
-				So(len(message2.CommitCalls()), ShouldEqual, 1)
-				So(len(message1.ReleaseCalls()), ShouldEqual, 1)
-				So(len(message2.ReleaseCalls()), ShouldEqual, 1)
+				So(len(message2.CommitAndReleaseCalls()), ShouldEqual, 1)
+				So(len(message1.CommitAndReleaseCalls()), ShouldEqual, 1)
 			})
 		})
 	})


### PR DESCRIPTION
### What

There seems to be a kafka lag as described in the ticket: https://trello.com/c/pqDXYOux/1379-investigate-and-fix-search-data-importer-not-consuming-events

On investigation these are the findings. 

 - Currently when an event is consumed by the dp search data importer this is added to a batch and the message is released. Please note that at this point it is not committed and only released. So this will add a lag to the kafka consumer group. So say if we receive 16 events in a minute , the lag count will be as follows 
 
```
GROUP                   TOPIC              PARTITION  CURRENT-OFFSET  LOG-END-OFFSET  LAG             CONSUMER-ID                                 HOST             CLIENT-ID
dp-search-data-importer search-data-import 0          18861           18877           16              sarama-bea65f56-26a7-447c-8f2f-beb885629e54 /0:0:0:0:0:0:0:1 sarama
```

- Now the batching will run after the expiry of the specified time, these events are processed and then only the batch will be committed and then the lag be removed. 
```
GROUP                   TOPIC              PARTITION  CURRENT-OFFSET  LOG-END-OFFSET  LAG             CONSUMER-ID                                 HOST             CLIENT-ID
dp-search-data-importer search-data-import 0          18877           18877           0               sarama-bea65f56-26a7-447c-8f2f-beb885629e54 /0:0:0:0:0:0:0:1 sarama
```
- So I assume this lag alert is mostly a false positive and is raised between the events ending up in the batch and it is processed after the expiry time, so that it will be committed to the consumer group.
- Now as a part of this pr, what I have done is whenever a message is received it is committed as well as released , so this lag won't be there and this won't cause an alert. 
- Locally this works .  

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
