### PR TITLE
remove info logs that are o little to no value

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -34,8 +34,6 @@ func NewBatchHandler(esClient dpelasticsearch.Client) *BatchHandler {
 
 // Handle the given slice of SearchDataImport Model.
 func (batchHandler BatchHandler) Handle(ctx context.Context, url string, events []*models.SearchDataImportModel) error {
-	log.Info(ctx, "events handler called")
-
 	// no events received. Nothing more to do.
 	if len(events) == 0 {
 		log.Info(ctx, "there are no events to handle")
@@ -48,7 +46,6 @@ func (batchHandler BatchHandler) Handle(ctx context.Context, url string, events 
 		return err
 	}
 
-	log.Info(ctx, "event successfully handled")
 	return nil
 }
 
@@ -126,7 +123,6 @@ func prepareEventForBulkUpsertRequestBody(ctx context.Context, sdModel *models.S
 			return nil, err
 		}
 
-		log.Info(ctx, "uid while preparing bulk request for upsert", log.Data{"uid": uid})
 		bulkbody = append(bulkbody, []byte("{ \""+"update"+"\": { \"_id\": \""+uid+"\" } }\n")...)
 		bulkbody = append(bulkbody, []byte("{")...)
 		bulkbody = append(bulkbody, []byte("\"doc\":")...)


### PR DESCRIPTION
### What

See title, logs removed that do not actually help us understand what is going on with the handling of messages consumed by the application, consequently removed.

The log outputting each documents unique identifier accounts for approximately 75% of logs and again is not needed and hence removed.

### How to review

- check changes make sense

### Who can review

Anyone
