### PR TITLE
Release/1.10.0

### DIFF
--- a/Dockerfile.concourse
+++ b/Dockerfile.concourse
@@ -1,4 +1,4 @@
-FROM onsdigital/dp-concourse-tools-ubuntu-22:ubuntu22.4-jammy-20250126
+FROM onsdigital/dp-concourse-tools-ubuntu-22:ubuntu22.4-jammy-20260509
 
 WORKDIR /app/
 

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.3-bookworm
+    tag: 1.26.4-bookworm
 
 inputs:
   - name: dp-search-data-importer

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.4-bookworm
+    tag: 1.26.5-bookworm
 
 inputs:
   - name: dp-search-data-importer

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.5-bookworm
+    tag: 1.26.6-bookworm
 
 inputs:
   - name: dp-search-data-importer

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-docker-go
-    tag: 1.26.5-dind-28
+    tag: 1.26.6-dind-28
 
 inputs:
   - name: dp-search-data-importer

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-docker-go
-    tag: 1.26.4-dind-28
+    tag: 1.26.5-dind-28
 
 inputs:
   - name: dp-search-data-importer

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-docker-go
-    tag: 1.26.3-dind-28
+    tag: 1.26.4-dind-28
 
 inputs:
   - name: dp-search-data-importer

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-node-go
-    tag: 1.26.3-bookworm-node-20
+    tag: 1.26.4-bookworm-node-24
 
 inputs:
   - name: dp-search-data-importer

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-node-go
-    tag: 1.26.5-bookworm-node-24
+    tag: 1.26.6-bookworm-node-24
 
 inputs:
   - name: dp-search-data-importer

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-node-go
-    tag: 1.26.4-bookworm-node-24
+    tag: 1.26.5-bookworm-node-24
 
 inputs:
   - name: dp-search-data-importer

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.3-bookworm
+    tag: 1.26.4-bookworm
 
 inputs:
   - name: dp-search-data-importer

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.4-bookworm
+    tag: 1.26.5-bookworm
 
 inputs:
   - name: dp-search-data-importer

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.5-bookworm
+    tag: 1.26.6-bookworm
 
 inputs:
   - name: dp-search-data-importer

--- a/cmd/producer/main.go
+++ b/cmd/producer/main.go
@@ -176,18 +176,7 @@ func scanImportEvent(scanner *bufio.Scanner) *models.SearchDataImport {
 	}
 
 	if dataType == DatasetDataType {
-		popType := models.PopulationType{}
 		dimensions := []models.Dimension{}
-
-		fmt.Println("Type the population type Name")
-		fmt.Printf("$ ")
-		scanner.Scan()
-		popType.Name = scanner.Text()
-
-		fmt.Println("Type the population type Label")
-		fmt.Printf("$ ")
-		scanner.Scan()
-		popType.Label = scanner.Text()
 
 		for {
 			fmt.Println("Add dimension? [Yy] to confirm")
@@ -217,7 +206,6 @@ func scanImportEvent(scanner *bufio.Scanner) *models.SearchDataImport {
 			dimensions = append(dimensions, dim)
 		}
 
-		searchDataImport.PopulationType = popType
 		searchDataImport.Dimensions = dimensions
 	}
 

--- a/features/import-search-data.feature
+++ b/features/import-search-data.feature
@@ -21,12 +21,6 @@ Feature: Search data imported to elasticsearch
         "DatasetID": "cphi01",
         "Edition":   "timeseries",
         "DataType":  "cantabular",
-        "PopulationType": {
-          "Key": "pop-label",
-          "AggKey": "pop-label###Pop Label",
-          "Name":  "popName",
-          "Label": "Pop Label"
-        },
         "Dimensions": [
           {
             "Key": "label-1",
@@ -63,12 +57,6 @@ Feature: Search data imported to elasticsearch
           "finalised":false,
           "published":false,
           "canonical_topic":"",
-          "population_type": {
-            "key": "pop-label",
-            "agg_key": "pop-label###Pop Label",
-            "name":  "popName",
-            "label": "Pop Label"
-          },
           "dimensions": [
  		        {
               "key": "label-1",

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -45,10 +45,6 @@ var (
 		Survey:          "",
 		Language:        "",
 		CanonicalTopic:  "",
-		PopulationType: models.PopulationType{
-			Name:  "pop1",
-			Label: "popLbl1",
-		},
 		Dimensions: []models.Dimension{
 			{Name: "dim1", Label: "dimLbl1", RawLabel: "dimRawLbl1"},
 		},

--- a/models/elastic.go
+++ b/models/elastic.go
@@ -23,7 +23,6 @@ type EsModel struct {
 	Language        string              `json:"language,omitempty"`
 	Survey          string              `json:"survey,omitempty"`
 	CanonicalTopic  string              `json:"canonical_topic"`
-	PopulationType  *EsPopulationType   `json:"population_type"`
 	Dimensions      []EsDimension       `json:"dimensions"`
 }
 
@@ -57,14 +56,6 @@ type EsBulkItemResponseError struct {
 type ReleaseDateChange struct {
 	ChangeNotice string `json:"change_notice"`
 	Date         string `json:"previous_date"`
-}
-
-// EsPopulationType represents the population type information in an elastic-search json
-type EsPopulationType struct {
-	Key    string `json:"key"`
-	AggKey string `json:"agg_key"`
-	Name   string `json:"name"`
-	Label  string `json:"label"`
 }
 
 // EsDimension represents a dimension in an elastic-search json

--- a/models/event.go
+++ b/models/event.go
@@ -25,7 +25,6 @@ type SearchDataImport struct {
 	Published       bool                 `avro:"published"`
 	Language        string               `avro:"language"`
 	Survey          string               `avro:"survey"`
-	PopulationType  PopulationType       `avro:"population_type"`
 	Dimensions      []Dimension          `avro:"dimensions"`
 }
 
@@ -43,15 +42,6 @@ type Dimension struct {
 	Name     string `avro:"name"`
 	Label    string `avro:"label"`
 	RawLabel string `avro:"raw_label"`
-}
-
-// PopulationType represents the population type name (unique ID) and label
-// and an aggregation key which combines name and label
-type PopulationType struct {
-	Key    string `avro:"key"`
-	AggKey string `avro:"agg_key"`
-	Name   string `avro:"name"`
-	Label  string `avro:"label"`
 }
 
 // DeleteEvent represents a delete event

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -48,15 +48,7 @@ var searchDataImportEvent = `{
         { "name": "label", "type": "string", "default": "" },
         { "name": "raw_label", "type": "string", "default": "" }
       ]
-    }}},
-    {"name": "population_type", "type": {
-      "name": "PopulationType", "type": "record", "fields": [
-        { "name": "key", "type": "string", "default": "" },
-        { "name": "agg_key", "type": "string", "default": "" },
-        { "name": "name", "type": "string", "default": ""},
-        { "name": "label", "type": "string", "default": ""}
-      ]
-    }}
+    }}}
   ]
 }`
 

--- a/specification.yml
+++ b/specification.yml
@@ -170,20 +170,6 @@ components:
                   type: string
                 raw_label:
                   type: string
-          population_type:
-            type: array
-            description: Array of population types, not currently used.
-            items:
-              type: object
-              properties:
-                key:
-                  type: string
-                agg_key:
-                  type: string
-                name:
-                  type: string
-                label:
-                  type: string
     search-content-deleted:
       name: search-content-deleted
       title: Content item has been deleted and should be removed from search

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -41,12 +41,6 @@ func (t *Transform) TransformEventModelToEsModel(eventModel *models.SearchDataIm
 		Language:        eventModel.Language,
 		CanonicalTopic:  eventModel.CanonicalTopic,
 	}
-	esModels.PopulationType = &models.EsPopulationType{
-		Key:    eventModel.PopulationType.Key,
-		AggKey: eventModel.PopulationType.AggKey,
-		Name:   eventModel.PopulationType.Name,
-		Label:  eventModel.PopulationType.Label,
-	}
 	for _, data := range eventModel.DateChanges {
 		esModels.DateChanges = append(esModels.DateChanges, models.ReleaseDateChange(data))
 	}

--- a/transform/transform_test.go
+++ b/transform/transform_test.go
@@ -37,11 +37,6 @@ func TestTransformEventModelToEsModel(t *testing.T) {
 					Date:         "test-date",
 				},
 			},
-			PopulationType: models.PopulationType{
-				Name:   "test-name",
-				Label:  "test-label",
-				AggKey: "test-name###test-label",
-			},
 			Dimensions: []models.Dimension{
 				{
 					Name:     "dim1",
@@ -81,11 +76,6 @@ func TestTransformEventModelToEsModel(t *testing.T) {
 						ChangeNotice: "test-notice",
 						Date:         "test-date",
 					},
-				},
-				PopulationType: &models.EsPopulationType{
-					Name:   "test-name",
-					Label:  "test-label",
-					AggKey: "test-name###test-label",
 				},
 				Dimensions: []models.EsDimension{
 					{


### PR DESCRIPTION
### What

- [chore(DIS-5035): upgrade dependencies to node 24](https://github.com/ONSdigital/dp-search-data-importer/commit/36bd24c8331b448351b0d96d05547bd52fe38b2f) @tjoluotch 
- [chore(DIS-5194): upgrade search imported to go 1.26.5 ](https://github.com/ONSdigital/dp-search-data-importer/commit/e0723dba580eac0990a099716d5fae224a5bf56c) @tjoluotch 
- [Bump go to 1.26.6](https://github.com/ONSdigital/dp-search-data-importer/commit/fbaf8dbd1aaabfbed3461df36d9e5028cfe920ef) @dhee-tree 
- [Update concourse build url](https://github.com/ONSdigital/dp-search-data-importer/commit/aee5a255ef4b50878e15da178cf907173ada9d18) @dhee-tree 
- [Remove population type](https://github.com/ONSdigital/dp-search-data-importer/commit/11746b9291c831f82b20855417785b8f476862f7) @dhee-tree 

### How to review

Check release is okay

### Who can review

!Me